### PR TITLE
Workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3581,7 +3581,7 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 [[package]]
 name = "zenoh"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "uhlc",
  "zenoh-buffers",
@@ -3671,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-core",
 ]
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "flume",
  "json5",
@@ -3697,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "aes 0.8.2",
  "hmac 0.12.1",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "bincode",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "libloading",
  "log",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "hex",
  "rand 0.8.5",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "bincode",
  "log",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,22 +30,22 @@ categories = ["network-programming"]
 
 [workspace.dependencies]
 async-std = "=1.12.0"
-async-trait = "0.1.57"
-clap = "3.2.12"
+async-trait = "0.1.60"
+clap = "3.2.23"
 derivative = "2.2.0"
 env_logger = "0.10.0"
 flume = "0.10.14"
-futures = "0.3.24"
+futures = "0.3.25"
 git-version = "0.3.5"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
 ntex = "0.5"
 ntex-mqtt = "0.9.1"
-regex = "1.6.0"
+regex = "1.7.0"
 rustc_version = "0.4"
-serde = "1.0.144"
-serde_json = "1.0.85"
+serde = "1.0.152"
+serde_json = "1.0.89"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = ["unstable"] }
 zenoh-collections = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }
 zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,42 @@ members = [
   "zplugin-mqtt",
 ]
 
+[workspace.package]
+version = "0.7.0-rc"
+authors = [
+    "Julien Enoch <julien@enoch.fr>",
+]
+edition = "2018"
+repository = "https://github.com/eclipse-zenoh/zenoh-plugin-mqtt"
+homepage = "http://zenoh.io"
+license = " EPL-2.0 OR Apache-2.0"
+categories = ["network-programming"]
+
+[workspace.dependencies]
+async-std = "=1.12.0"
+async-trait = "0.1.57"
+clap = "3.2.12"
+derivative = "2.2.0"
+env_logger = "0.10.0"
+flume = "0.10.14"
+futures = "0.3.24"
+git-version = "0.3.5"
+hex = "0.4.3"
+lazy_static = "1.4.0"
+log = "0.4.17"
+ntex = "0.5"
+ntex-mqtt = "0.9.1"
+regex = "1.6.0"
+rustc_version = "0.4"
+serde = "1.0.144"
+serde_json = "1.0.85"
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = ["unstable"] }
+zenoh-collections = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }
+zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }
+zenoh-ext = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = ["unstable"] }
+zenoh-plugin-rest = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", default-features = false }
+zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", default-features = false }
+
 [profile.release]
 debug = false
 lto = "fat"

--- a/zenoh-bridge-mqtt/Cargo.toml
+++ b/zenoh-bridge-mqtt/Cargo.toml
@@ -31,7 +31,7 @@ log = { workspace = true }
 serde_json = { workspace = true }
 zenoh = { workspace = true }
 zenoh-plugin-rest = { workspace = true }
-zenoh-plugin-trait.workspace = true
+zenoh-plugin-trait = { workspace = true }
 zplugin-mqtt = { path = "../zplugin-mqtt/", default-features = false }
 
 [[bin]]

--- a/zenoh-bridge-mqtt/Cargo.toml
+++ b/zenoh-bridge-mqtt/Cargo.toml
@@ -13,31 +13,26 @@
 #
 [package]
 name = "zenoh-bridge-mqtt"
-version = "0.7.0-rc"
-authors = [
-    "Julien Enoch <julien@enoch.fr>",
-]
-edition = "2018"
-repository = "https://github.com/eclipse-zenoh/zenoh-plugin-mqtt"
-homepage = "http://zenoh.io"
-license = " EPL-2.0 OR Apache-2.0"
-categories = ["network-programming"]
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+categories.workspace = true
 description = "Zenoh bridge for MQTT"
 
 [dependencies]
-clap = "3.2.12"
-env_logger = "0.10.0"
-lazy_static = "1.4.0"
-log = "0.4"
-serde_json = "1.0.71"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = ["unstable"] }
-zenoh-plugin-rest = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", default-features = false }
-zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", default-features = false }
-zplugin-mqtt = { path = "../zplugin-mqtt", default-features = false }
-
-[dependencies.async-std]
-version = "=1.12.0"
-features = ["unstable", "attributes"]
+async-std = { workspace = true, features = ["unstable", "attributes"] }
+clap.workspace = true
+env_logger.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+serde_json.workspace = true
+zenoh.workspace = true
+zenoh-plugin-rest.workspace = true
+zenoh-plugin-trait.workspace = true
+zplugin-mqtt = { path = "../zplugin-mqtt/", default-features = false }
 
 [[bin]]
 name = "zenoh-bridge-mqtt"

--- a/zenoh-bridge-mqtt/Cargo.toml
+++ b/zenoh-bridge-mqtt/Cargo.toml
@@ -13,24 +13,24 @@
 #
 [package]
 name = "zenoh-bridge-mqtt"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
-repository.workspace = true
-homepage.workspace = true
-license.workspace = true
-categories.workspace = true
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+categories = { workspace = true }
 description = "Zenoh bridge for MQTT"
 
 [dependencies]
 async-std = { workspace = true, features = ["unstable", "attributes"] }
-clap.workspace = true
-env_logger.workspace = true
-lazy_static.workspace = true
-log.workspace = true
-serde_json.workspace = true
-zenoh.workspace = true
-zenoh-plugin-rest.workspace = true
+clap = { workspace = true }
+env_logger = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
+serde_json = { workspace = true }
+zenoh = { workspace = true }
+zenoh-plugin-rest = { workspace = true }
 zenoh-plugin-trait.workspace = true
 zplugin-mqtt = { path = "../zplugin-mqtt/", default-features = false }
 

--- a/zplugin-mqtt/Cargo.toml
+++ b/zplugin-mqtt/Cargo.toml
@@ -13,15 +13,13 @@
 #
 [package]
 name = "zplugin-mqtt"
-version = "0.7.0-rc"
-authors = [
-    "Julien Enoch <julien@enoch.fr>",
-]
-edition = "2018"
-repository = "https://github.com/eclipse-zenoh/zenoh-plugin-mqtt"
-homepage = "http://zenoh.io"
-license = " EPL-2.0 OR Apache-2.0"
-categories = ["network-programming"]
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+categories.workspace = true
 description = "Zenoh plugin for MQTT"
 
 [lib]
@@ -29,36 +27,33 @@ name = "zplugin_mqtt"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-no_mangle = ["zenoh-plugin-trait/no_mangle"]
 default = ["no_mangle"]
+no_mangle = ["zenoh-plugin-trait/no_mangle"]
 
 [dependencies]
-async-trait = "0.1.57"
-derivative = "2.2.0"
-env_logger = "0.10.0"
-flume = "0.10.14"
-futures = "0.3.24"
-git-version = "0.3.5"
-hex = "0.4.3"
-lazy_static = "1.4.0"
-log = "0.4.17"
-ntex = { version = "0.5", features = ["async-std", "rustls"] }
-ntex-mqtt = "0.9.1"
-regex = "1.6.0"
-serde = "1.0.144"
-serde_json = "1.0.85"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = ["unstable"] }
-zenoh-collections = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }
-zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }
-zenoh-ext = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = ["unstable"] }
-zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", default-features = false }
-
-[dependencies.async-std]
-version = "=1.12.0"
-features = ["unstable", "attributes"]
+async-std = { workspace = true, features = ["unstable", "attributes"] }
+async-trait.workspace = true
+derivative.workspace = true
+env_logger.workspace = true
+flume.workspace = true
+futures.workspace = true
+git-version.workspace = true
+hex.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+ntex = { workspace = true, features = ["async-std", "rustls"] }
+ntex-mqtt.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+zenoh.workspace = true
+zenoh-collections.workspace = true
+zenoh-core.workspace = true
+zenoh-ext.workspace = true
+zenoh-plugin-trait.workspace = true
 
 [build-dependencies]
-rustc_version = "0.4"
+rustc_version.workspace = true
 
 [package.metadata.deb]
 name = "zenoh-plugin-mqtt"

--- a/zplugin-mqtt/Cargo.toml
+++ b/zplugin-mqtt/Cargo.toml
@@ -13,13 +13,13 @@
 #
 [package]
 name = "zplugin-mqtt"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
-repository.workspace = true
-homepage.workspace = true
-license.workspace = true
-categories.workspace = true
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+categories = { workspace = true }
 description = "Zenoh plugin for MQTT"
 
 [lib]
@@ -32,28 +32,28 @@ no_mangle = ["zenoh-plugin-trait/no_mangle"]
 
 [dependencies]
 async-std = { workspace = true, features = ["unstable", "attributes"] }
-async-trait.workspace = true
-derivative.workspace = true
-env_logger.workspace = true
-flume.workspace = true
-futures.workspace = true
-git-version.workspace = true
-hex.workspace = true
-lazy_static.workspace = true
-log.workspace = true
+async-trait = { workspace = true }
+derivative = { workspace = true }
+env_logger = { workspace = true }
+flume = { workspace = true }
+futures = { workspace = true }
+git-version = { workspace = true }
+hex = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
 ntex = { workspace = true, features = ["async-std", "rustls"] }
-ntex-mqtt.workspace = true
-regex.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-zenoh.workspace = true
-zenoh-collections.workspace = true
-zenoh-core.workspace = true
-zenoh-ext.workspace = true
-zenoh-plugin-trait.workspace = true
+ntex-mqtt = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+zenoh = { workspace = true }
+zenoh-collections = { workspace = true }
+zenoh-core = { workspace = true }
+zenoh-ext = { workspace = true }
+zenoh-plugin-trait = { workspace = true }
 
 [build-dependencies]
-rustc_version.workspace = true
+rustc_version = { workspace = true }
 
 [package.metadata.deb]
 name = "zenoh-plugin-mqtt"


### PR DESCRIPTION
Dependencies moved to workspace. See [this](https://github.com/eclipse-zenoh/zenoh/pull/420) for reference.