### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Report a bug
+description: |
+  Create a bug report to help us improve Zenoh.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Describe the bug"
+      description: |
+        A clear and concise description of the expected behaviour and what the bug is.
+      placeholder: |
+        E.g. zenoh peers can not automatically establish a connection.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To reproduce
+      description: "Steps to reproduce the behavior:"
+      placeholder: | 
+        1. Start a subscriber "..."
+        2. Start a publisher "...."
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: system
+    attributes:
+      label: System info
+      description: "Please complete the following information:"
+      placeholder: |
+        - Platform: [e.g. Ubuntu 20.04 64-bit]
+        - CPU [e.g. AMD Ryzen 3800X]
+        - Zenoh version/commit [e.g. 6f172ea985d42d20d423a192a2d0d46bb0ce0d11]
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/eclipse-zenoh/roadmap/discussions/categories/zenoh
+    about: Open to the Zenoh community. Share your feedback with the Zenoh team.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Request a feature
+description: |
+  Suggest a new feature specific to this repository. NOTE: for generic Zenoh ideas use "Ask a question".
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Guidelines for a good issue**
+
+        *Is your feature request related to a problem?*
+        A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+        *Describe the solution you'd like*
+        A clear and concise description of what you want to happen.
+
+        *Describe alternatives you've considered*
+        A clear and concise description of any alternative solutions or features you've considered.
+
+        *Additional context*
+        Add any other context about the feature request here.
+  - type: textarea
+    id: feature
+    attributes:
+      label: "Describe the feature"
+    validations:
+      required: true


### PR DESCRIPTION
This PR adds the same GitHub issue template as used in all the other Zenoh repositories.