### PR TITLE
Remove unnecessary block_on

### DIFF
--- a/zenoh-bridge-mqtt/src/main.rs
+++ b/zenoh-bridge-mqtt/src/main.rs
@@ -185,5 +185,5 @@ async fn main() {
     // start MQTT plugin
     use zenoh_plugin_trait::Plugin;
     zplugin_mqtt::MqttPlugin::start("mqtt", &runtime).unwrap();
-    async_std::task::block_on(async_std::future::pending::<()>());
+    async_std::future::pending::<()>().await;
 }


### PR DESCRIPTION
`block_on` on a pending future will steal the thread from the executor. 
Better awaiting and the pending future instead.