### PR TITLE
Debian package: add conffiles and RestartSec=2

### DIFF
--- a/zenoh-bridge-mqtt/.service/zenoh-bridge-mqtt.service
+++ b/zenoh-bridge-mqtt/.service/zenoh-bridge-mqtt.service
@@ -14,6 +14,7 @@ KillMode=mixed
 KillSignal=SIGINT
 RestartKillSignal=SIGINT
 Restart=on-failure
+RestartSec=2
 PermissionsStartOnly=true
 User=zenoh-bridge-mqtt
 StandardOutput=syslog

--- a/zenoh-bridge-mqtt/Cargo.toml
+++ b/zenoh-bridge-mqtt/Cargo.toml
@@ -67,3 +67,4 @@ assets = [
         "644",
     ],
 ]
+conf-files = ["/etc/zenoh-bridge-mqtt/conf.json5"]


### PR DESCRIPTION
Improve Debian packaging and service:
- Add [conffiles](https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles) similarly to https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/pull/121
- Add `RestartSec=2` for service, similarly to https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/pull/112