### PR TITLE
zenoh-bridge-mqtt: fix Zenoh Runtime startup

### DIFF
--- a/zenoh-bridge-mqtt/src/main.rs
+++ b/zenoh-bridge-mqtt/src/main.rs
@@ -215,7 +215,7 @@ async fn main() {
     plugins_mgr = plugins_mgr.declare_static_plugin::<zenoh_plugin_mqtt::MqttPlugin>(true);
 
     // create a zenoh Runtime.
-    let runtime = match RuntimeBuilder::new(config)
+    let mut runtime = match RuntimeBuilder::new(config)
         .plugins_manager(plugins_mgr)
         .build()
         .await
@@ -226,11 +226,10 @@ async fn main() {
             std::process::exit(-1);
         }
     };
-    // create a zenoh Session.
-    let _session = zenoh::init(runtime).res().await.unwrap_or_else(|e| {
-        println!("{e}. Exiting...");
+    if let Err(e) = runtime.start().await {
+        println!("Failed to start Zenoh runtime: {e}. Exiting...");
         std::process::exit(-1);
-    });
+    }
 
     async_std::future::pending::<()>().await;
 }


### PR DESCRIPTION
Following #75 and #81, the `zenoh-bridge-mqtt` was not starting properly: the Zenoh stack was not running and no zenoh communication occurred.

This fixes this issue, calling the missing `runtime.start()` in main.