### PR TITLE
Admin space: change prefix from '@/service/<uuid>/mqtt' to '@mqtt/<uuid>'

### DIFF
--- a/zenoh-plugin-mqtt/src/lib.rs
+++ b/zenoh-plugin-mqtt/src/lib.rs
@@ -52,7 +52,7 @@ macro_rules! ke_for_sure {
 }
 
 lazy_static::lazy_static! {
-    static ref KE_PREFIX_ADMIN_SPACE: &'static keyexpr = ke_for_sure!("@/service");
+    static ref KE_PREFIX_ADMIN_SPACE: &'static keyexpr = ke_for_sure!("@mqtt");
     static ref ADMIN_SPACE_KE_VERSION: &'static keyexpr = ke_for_sure!("version");
     static ref ADMIN_SPACE_KE_CONFIG: &'static keyexpr = ke_for_sure!("config");
 }
@@ -134,8 +134,7 @@ async fn run(
     };
 
     // declare admin space queryable
-    let admin_keyexpr_prefix =
-        *KE_PREFIX_ADMIN_SPACE / &zsession.zid().into_keyexpr() / ke_for_sure!("mqtt");
+    let admin_keyexpr_prefix = *KE_PREFIX_ADMIN_SPACE / &zsession.zid().into_keyexpr();
     let admin_keyexpr_expr = (&admin_keyexpr_prefix) / ke_for_sure!("**");
     tracing::debug!("Declare admin space on {}", admin_keyexpr_expr);
     let config2 = config.clone();


### PR DESCRIPTION
The plugin had its admin space under `@/service/<uuid>/mqtt/**`.
The main drawback is that it's mixed with Zenoh's admin space which is prefixed with `@/`.

For separation of concerns and for coherency with the plugin for ROS2 which uses `@ros2/<uuid>` as prefix, this PR changes the admin prefix for MQTT plugin to `@mqtt/<uuid>`

Migration guide:
- `@/service/<uuid>/mqtt/version` becomes:
   `@mqtt/<uuid>/version`
- `@/service/<uuid>/mqtt/config` becomes:
   `@mqtt/<uuid>/config`
