### PR TITLE
chore: renamed no_mangle feature to dynamic_plugin

### DIFF
--- a/zenoh-plugin-mqtt/Cargo.toml
+++ b/zenoh-plugin-mqtt/Cargo.toml
@@ -27,8 +27,8 @@ name = "zenoh_plugin_mqtt"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["no_mangle"]
-no_mangle = []
+default = ["dynamic_plugin"]
+dynamic_plugin = []
 stats = ["zenoh/stats"]
 
 [dependencies]

--- a/zenoh-plugin-mqtt/src/lib.rs
+++ b/zenoh-plugin-mqtt/src/lib.rs
@@ -57,7 +57,7 @@ lazy_static::lazy_static! {
     static ref ADMIN_SPACE_KE_CONFIG: &'static keyexpr = ke_for_sure!("config");
 }
 
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(MqttPlugin);
 
 pub struct MqttPlugin;


### PR DESCRIPTION
As suggested by @milyin this PR renames the `no_mangle` feature to `dynamic_plugin` which is easier to understand.
- Sister of: https://github.com/eclipse-zenoh/zenoh/pull/1010