### PR TITLE
Fix release workflow to use docker image attribute

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,28 +159,7 @@ jobs:
       version: ${{ needs.tag.outputs.version }}
       repo: ${{ github.repository }}
       branch: ${{ needs.tag.outputs.branch }}
-      tags: "eclipse/zenoh-bridge-mqtt:${{ needs.tag.outputs.version }}"
-      binary: zenoh-bridge-mqtt
-      files: |
-        zenoh-bridge-mqtt
-        libzenoh_plugin_mqtt.so
-      platforms: |
-        linux/arm64
-        linux/amd64
-      licenses: EPL-2.0 OR Apache-2.0
-    secrets: inherit
-
-  ghcr:
-    name: Publish container image to GitHub Container Registry
-    needs: [tag, build-standalone]
-    uses: eclipse-zenoh/ci/.github/workflows/release-crates-ghcr.yml@main
-    with:
-      no-build: true
-      live-run: true
-      version: ${{ needs.tag.outputs.version }}
-      repo: ${{ github.repository }}
-      branch: ${{ needs.tag.outputs.branch }}
-      tags: "ghcr.io/${{ github.repository }}:${{ needs.tag.outputs.version }}"
+      image: "eclipse/zenoh-bridge-mqtt"
       binary: zenoh-bridge-mqtt
       files: |
         zenoh-bridge-mqtt


### PR DESCRIPTION
In https://github.com/eclipse-zenoh/ci/pull/129/files, the action to release docker images was changed to use an image attribute instead of tags, so we can properly tag latest and nightly releases.