### PR TITLE
fix: set live-run to input's value in dockerhub publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
     uses: eclipse-zenoh/ci/.github/workflows/release-crates-dockerhub.yml@main
     with:
       no-build: true
-      live-run: true
+      live-run: ${{ inputs.live-run || false }}
       version: ${{ needs.tag.outputs.version }}
       repo: ${{ github.repository }}
       branch: ${{ needs.tag.outputs.branch }}


### PR DESCRIPTION
In eclipse-zenoh/ci#129 the docker publish action was changed to use an image attribute and use the live-run attribute to decide between publishing nightly or latest tags, thus we need to set the live-run accordingly.