### PR TITLE
fix: align workflow name with rest of repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
-name: Rust
+name: CI
 
 on:
   push:


### PR DESCRIPTION
All the eclipse-zenoh/* repos use CI as the name for their ci.yml workflow. This change just make things consistent