### PR TITLE
Bump ntex, ntex-mqtt, and other crate version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
+dependencies = [
+ "event-listener 5.3.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite 0.2.14",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,9 +446,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -465,6 +477,33 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234314bd569802ec87011d653d6815c6d7b9ffb969e9fee5b8b20ef860e8dce9"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
 
 [[package]]
 name = "backtrace"
@@ -524,6 +563,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.77",
+ "which",
 ]
 
 [[package]]
@@ -638,6 +700,8 @@ version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -646,6 +710,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -700,6 +773,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +805,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -874,6 +967,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1085,12 @@ dependencies = [
  "quote",
  "syn 2.0.77",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1141,6 +1250,12 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1343,6 +1458,12 @@ dependencies = [
  "quote",
  "syn 2.0.77",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -1630,6 +1751,15 @@ checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1662,6 +1792,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1746,6 +1885,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -1869,6 +2014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,13 +2058,13 @@ dependencies = [
 
 [[package]]
 name = "ntex"
-version = "0.7.17"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8da0767496674cfc59663af137b9487a1af597809ba952be07d742f4f75fef"
+checksum = "93daf570cdedb9a01a3020ccd367b2ff37402b30c979aff2da23e3e84d2b6cfc"
 dependencies = [
- "async-channel 2.3.1",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
+ "bytes",
  "encoding_rs",
  "httparse",
  "httpdate",
@@ -1922,30 +2073,27 @@ dependencies = [
  "nanorand",
  "ntex-bytes",
  "ntex-codec",
- "ntex-connect",
  "ntex-h2",
  "ntex-http",
  "ntex-io",
  "ntex-macros",
+ "ntex-net",
  "ntex-router",
  "ntex-rt",
+ "ntex-server",
  "ntex-service",
  "ntex-tls",
- "ntex-tokio",
  "ntex-util",
- "oneshot",
  "percent-encoding",
  "pin-project-lite 0.2.14",
- "polling 3.7.3",
  "regex",
- "rustls 0.21.12",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sha-1",
- "socket2 0.5.7",
  "thiserror",
- "webpki-roots 0.25.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1970,30 +2118,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntex-connect"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9c711a3564135ae0e499882da4a5b6cd8dfdd818dcc57e26e146aec541abe7"
-dependencies = [
- "log",
- "ntex-bytes",
- "ntex-http",
- "ntex-io",
- "ntex-rt",
- "ntex-service",
- "ntex-tls",
- "ntex-tokio",
- "ntex-util",
- "rustls 0.21.12",
- "thiserror",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
 name = "ntex-h2"
-version = "0.4.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138b90775e51cfb9e0a6df6b8f12cfb80ee1d23344a02a138385844061c388fb"
+checksum = "98763f0ee78f247c02fe1bcdf6380f306a08d95169f9c2d83619d5e1cb26c738"
 dependencies = [
  "bitflags 2.6.0",
  "fxhash",
@@ -2001,10 +2129,9 @@ dependencies = [
  "nanorand",
  "ntex-bytes",
  "ntex-codec",
- "ntex-connect",
  "ntex-http",
  "ntex-io",
- "ntex-rt",
+ "ntex-net",
  "ntex-service",
  "ntex-util",
  "pin-project-lite 0.2.14",
@@ -2027,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-io"
-version = "0.3.17"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c21a70836a8bfd9a673ee86dcf37d35e23b06449faa70bed25ce7c75ca0e81"
+checksum = "ec68a2766bcc47426631e3461c8d7994f6eec194445f394ab61f83d92756ad12"
 dependencies = [
  "bitflags 2.6.0",
  "log",
@@ -2053,16 +2180,39 @@ dependencies = [
 
 [[package]]
 name = "ntex-mqtt"
-version = "0.12.16"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4a66a0bcd070f5af0709e3959d6f96ef002deaebd3aa69e5ff8905ded10bf9"
+checksum = "103619256f5941b91989f3547f0b91ef269863c5e843d8f20acf19b563901d87"
 dependencies = [
  "bitflags 2.6.0",
  "log",
- "ntex",
+ "ntex-bytes",
+ "ntex-codec",
+ "ntex-io",
+ "ntex-net",
+ "ntex-router",
+ "ntex-service",
+ "ntex-util",
  "pin-project-lite 0.2.14",
  "serde",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ntex-net"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f3d87616c8fc39c41d432402d98a118861e8e144df30037fe1400cdd29ac35"
+dependencies = [
+ "log",
+ "ntex-bytes",
+ "ntex-http",
+ "ntex-io",
+ "ntex-rt",
+ "ntex-service",
+ "ntex-tokio",
+ "ntex-util",
  "thiserror",
 ]
 
@@ -2093,49 +2243,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntex-service"
-version = "1.2.7"
+name = "ntex-server"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ed5da53199c78416207467c565502e191a2c3b3b8f77edfe0560fef117af86"
+checksum = "1b9c3f4b038d1bcc3aff4e457a4b8258828b8e119c9ef4fd1e42c8df5e732cee"
 dependencies = [
- "pin-project-lite 0.2.14",
+ "async-broadcast",
+ "async-channel 2.3.1",
+ "ctrlc",
+ "log",
+ "ntex-bytes",
+ "ntex-net",
+ "ntex-rt",
+ "ntex-service",
+ "ntex-util",
+ "oneshot",
+ "polling 3.7.3",
+ "signal-hook",
+ "socket2 0.5.7",
+]
+
+[[package]]
+name = "ntex-service"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcebe6c7fa4d346646ef94c29957aab40078e91cd4c73ef3a1394f2a49de50d4"
+dependencies = [
  "slab",
 ]
 
 [[package]]
 name = "ntex-tls"
-version = "0.3.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfa487eb2ee31f0e3e097f17d6a895add0ee2a1ffd83806e5cca5d40e935536"
+checksum = "6e08948d9a1d27d11c474c374e6b8c0eee7e2dd4a288967d5dcce13d7adbd80e"
 dependencies = [
  "log",
  "ntex-bytes",
  "ntex-io",
+ "ntex-net",
  "ntex-service",
  "ntex-util",
- "pin-project-lite 0.2.14",
- "rustls 0.21.12",
+ "rustls",
 ]
 
 [[package]]
 name = "ntex-tokio"
-version = "0.3.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9810c166939940255f1e42a50dffb889801fe3fbe84dfd7ab342301338a6c4"
+checksum = "623868ff022f737d7b94212dc85e471f895e58f6c59c72552cdc9a22c5f167ed"
 dependencies = [
  "log",
  "ntex-bytes",
  "ntex-io",
  "ntex-util",
- "pin-project-lite 0.2.14",
  "tokio",
 ]
 
 [[package]]
 name = "ntex-util"
-version = "0.3.4"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3376de7b99ba5209c1d73bf62bb3642f5158a26dac6347321088ea848c84019b"
+checksum = "cb89227b7c7b6850e17be71b1abe711e2b6e96d8e386b76ea259c155c4ab65d4"
 dependencies = [
  "bitflags 2.6.0",
  "futures-core",
@@ -2645,6 +2814,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,8 +2848,8 @@ dependencies = [
  "pin-project-lite 0.2.14",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
- "rustls 0.23.13",
+ "rustc-hash 2.0.0",
+ "rustls",
  "socket2 0.5.7",
  "thiserror",
  "tokio",
@@ -2686,8 +2865,8 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash",
- "rustls 0.23.13",
+ "rustc-hash 2.0.0",
+ "rustls",
  "rustls-platform-verifier",
  "slab",
  "thiserror",
@@ -2923,6 +3102,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
@@ -2983,27 +3168,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3048,13 +3222,13 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.13",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.5",
+ "webpki-roots",
  "winapi",
 ]
 
@@ -3066,20 +3240,11 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3139,16 +3304,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secrecy"
@@ -3410,6 +3565,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3872,7 +4037,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -4336,17 +4501,23 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.37",
 ]
 
 [[package]]
@@ -4565,7 +4736,7 @@ dependencies = [
  "flume",
  "futures",
  "git-version",
- "itertools",
+ "itertools 0.13.0",
  "json5",
  "lazy_static",
  "once_cell",
@@ -4729,8 +4900,8 @@ dependencies = [
  "async-trait",
  "flume",
  "futures",
- "rustls 0.23.13",
- "rustls-webpki 0.102.8",
+ "rustls",
+ "rustls-webpki",
  "serde",
  "tokio",
  "tokio-util",
@@ -4752,15 +4923,15 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "quinn",
- "rustls 0.23.13",
+ "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "secrecy",
  "tokio",
  "tokio-util",
  "tracing",
- "webpki-roots 0.26.5",
+ "webpki-roots",
  "x509-parser",
  "zenoh-config",
  "zenoh-core",
@@ -4793,17 +4964,17 @@ source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a6c69946f7b
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "rustls 0.23.13",
+ "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "secrecy",
  "socket2 0.5.7",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tracing",
- "webpki-roots 0.26.5",
+ "webpki-roots",
  "x509-parser",
  "zenoh-config",
  "zenoh-core",
@@ -4887,7 +5058,7 @@ version = "1.0.0-dev"
 dependencies = [
  "async-channel 2.3.1",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "derivative",
  "flume",
  "futures",
@@ -4899,7 +5070,7 @@ dependencies = [
  "ntex-tls",
  "regex",
  "rustc_version 0.4.1",
- "rustls 0.21.12",
+ "rustls",
  "rustls-pemfile",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ repository = "https://github.com/eclipse-zenoh/zenoh-plugin-mqtt"
 version = "1.0.0-dev"
 
 [workspace.dependencies]
-async-channel = "2.2.0"
-async-trait = "0.1.66"
-base64 = "0.21.4"
+async-channel = "2.3.1"
+async-trait = "0.1.83"
+base64 = "0.22.1"
 clap = "3.2.23"
 derivative = "2.2.0"
 flume = "0.11"
@@ -35,18 +35,18 @@ futures = "0.3.26"
 git-version = "0.3.5"
 hex = "0.4.3"
 lazy_static = "1.4.0"
-ntex = { version = "0.7.17", features = ["tokio", "rustls"] }
-ntex-mqtt = "0.12.16"
-ntex-tls = "0.3.2"
+ntex = { version = "2.6.0", features = ["tokio", "rustls"] }
+ntex-mqtt = "3.1.0"
+ntex-tls = "2.2.0"
 regex = "1.7.1"
 rustc_version = "0.4"
-rustls = "0.21.7"
+rustls = "0.23.13"
 rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.1.0"
 secrecy = { version = "0.8.0", features = ["alloc", "serde"] }
-serde = "1.0.154"
-serde_json = "1.0.117"
-tokio = { version = "1.35.1", default-features = false } # Default features are disabled due to some crates' requirements
+serde = "1.0.210"
+serde_json = "1.0.128"
+tokio = { version = "1.40.0", default-features = false } # Default features are disabled due to some crates' requirements
 tracing = "0.1"
 zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
   "plugins",

--- a/zenoh-bridge-mqtt/src/main.rs
+++ b/zenoh-bridge-mqtt/src/main.rs
@@ -221,7 +221,7 @@ async fn main() {
         plugins_mgr.declare_static_plugin::<zenoh_plugin_rest::RestPlugin, &str>("rest", true);
     }
 
-    // declare ROS2DDS plugin
+    // declare MQTT plugin
     plugins_mgr.declare_static_plugin::<zenoh_plugin_mqtt::MqttPlugin, &str>("mqtt", true);
 
     // create a zenoh Runtime.

--- a/zenoh-plugin-mqtt/src/lib.rs
+++ b/zenoh-plugin-mqtt/src/lib.rs
@@ -25,14 +25,15 @@ use std::{
 use ntex::{
     io::IoBoxed,
     service::{chain_factory, fn_factory_with_config, fn_service},
-    time::Deadline,
     util::{ByteString, Bytes, Ready},
     ServiceFactory,
 };
 use ntex_mqtt::{v3, v5, MqttError, MqttServer};
-use ntex_tls::rustls::Acceptor;
+use ntex_tls::rustls::TlsAcceptor;
 use rustls::{
-    server::AllowAnyAuthenticatedClient, Certificate, PrivateKey, RootCertStore, ServerConfig,
+    pki_types::{CertificateDer, PrivateKeyDer},
+    server::WebPkiClientVerifier,
+    RootCertStore, ServerConfig,
 };
 use secrecy::ExposeSecret;
 use serde_json::Value;
@@ -217,7 +218,7 @@ async fn run(
                         "mqtt",
                         config.port.clone(),
                         move |_| {
-                            chain_factory(Acceptor::new(tls.clone()))
+                            chain_factory(TlsAcceptor::new(tls.clone()))
                                 .map_err(|err| MqttError::Service(MqttPluginError::from(err)))
                                 .and_then(create_mqtt_server(
                                     zsession.clone(),
@@ -316,14 +317,12 @@ fn create_tls_config(config: &TLSConfig) -> ZResult<Arc<ServerConfig>> {
             let root_cert_store = load_trust_anchors(bytes)?;
 
             ServerConfig::builder()
-                .with_safe_defaults()
-                .with_client_cert_verifier(Arc::new(AllowAnyAuthenticatedClient::new(
-                    root_cert_store,
-                )))
+                .with_client_cert_verifier(
+                    WebPkiClientVerifier::builder(root_cert_store.into()).build()?,
+                )
                 .with_single_cert(certs, key)?
         }
         None => ServerConfig::builder()
-            .with_safe_defaults()
             .with_no_client_auth()
             .with_single_cert(certs, key)?,
     };
@@ -337,21 +336,15 @@ pub fn base64_decode(data: &str) -> ZResult<Vec<u8>> {
         .map_err(|e| zerror!("Unable to perform base64 decoding: {e:?}"))?)
 }
 
-fn load_private_key(bytes: Vec<u8>) -> ZResult<PrivateKey> {
+fn load_private_key(bytes: Vec<u8>) -> ZResult<PrivateKeyDer<'static>> {
     let mut reader = BufReader::new(bytes.as_slice());
 
     loop {
         match rustls_pemfile::read_one(&mut reader) {
             Ok(item) => match item {
-                Some(rustls_pemfile::Item::Pkcs1Key(key)) => {
-                    return Ok(rustls::PrivateKey(key.secret_pkcs1_der().to_vec()))
-                }
-                Some(rustls_pemfile::Item::Pkcs8Key(key)) => {
-                    return Ok(rustls::PrivateKey(key.secret_pkcs8_der().to_vec()))
-                }
-                Some(rustls_pemfile::Item::Sec1Key(key)) => {
-                    return Ok(rustls::PrivateKey(key.secret_sec1_der().to_vec()))
-                }
+                Some(rustls_pemfile::Item::Pkcs1Key(key)) => return Ok(key.into()),
+                Some(rustls_pemfile::Item::Pkcs8Key(key)) => return Ok(key.into()),
+                Some(rustls_pemfile::Item::Sec1Key(key)) => return Ok(key.into()),
                 None => break,
                 _ => continue,
             },
@@ -361,11 +354,10 @@ fn load_private_key(bytes: Vec<u8>) -> ZResult<PrivateKey> {
     Err(zerror!("No supported private keys found").into())
 }
 
-fn load_certs(bytes: Vec<u8>) -> ZResult<Vec<Certificate>> {
+fn load_certs(bytes: Vec<u8>) -> ZResult<Vec<CertificateDer<'static>>> {
     let mut reader = BufReader::new(bytes.as_slice());
 
-    let certs: Vec<Certificate> = rustls_pemfile::certs(&mut reader)
-        .map(|c| c.map(|c| Certificate(c.to_vec())))
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut reader)
         .collect::<Result<_, _>>()
         .map_err(|err| zerror!("Error processing client certificate: {err}."))?;
 
@@ -379,7 +371,7 @@ fn load_trust_anchors(bytes: Vec<u8>) -> ZResult<RootCertStore> {
     let mut root_cert_store = RootCertStore::empty();
     let roots = load_certs(bytes)?;
     for root in roots {
-        root_cert_store.add(&root)?;
+        root_cert_store.add(root)?;
     }
     Ok(root_cert_store)
 }
@@ -443,20 +435,8 @@ fn create_mqtt_server(
     config: Arc<Config>,
     auth_dictionary: Arc<Option<HashMap<User, Password>>>,
 ) -> MqttServer<
-    impl ServiceFactory<
-        (IoBoxed, Deadline),
-        (),
-        Response = (),
-        Error = MqttError<MqttPluginError>,
-        InitError = (),
-    >,
-    impl ServiceFactory<
-        (IoBoxed, Deadline),
-        (),
-        Response = (),
-        Error = MqttError<MqttPluginError>,
-        InitError = (),
-    >,
+    impl ServiceFactory<IoBoxed, (), Response = (), Error = MqttError<MqttPluginError>, InitError = ()>,
+    impl ServiceFactory<IoBoxed, (), Response = (), Error = MqttError<MqttPluginError>, InitError = ()>,
     MqttPluginError,
     (),
 > {
@@ -646,8 +626,8 @@ async fn publish_v3(
 
 async fn control_v3(
     session: v3::Session<MqttSessionState>,
-    control: v3::ControlMessage<MqttPluginError>,
-) -> Result<v3::ControlResult, MqttPluginError> {
+    control: v3::Control<MqttPluginError>,
+) -> Result<v3::ControlAck, MqttPluginError> {
     tracing::trace!(
         "MQTT client {} sent control: {:?}",
         session.client_id,
@@ -655,13 +635,13 @@ async fn control_v3(
     );
 
     match control {
-        v3::ControlMessage::Ping(ref msg) => Ok(msg.ack()),
-        v3::ControlMessage::Disconnect(msg) => {
+        v3::Control::Ping(ref msg) => Ok(msg.ack()),
+        v3::Control::Disconnect(msg) => {
             tracing::debug!("MQTT client {} disconnected", session.client_id);
             session.sink().close();
             Ok(msg.ack())
         }
-        v3::ControlMessage::Subscribe(mut msg) => {
+        v3::Control::Subscribe(mut msg) => {
             for mut s in msg.iter_mut() {
                 let topic = s.topic().as_str();
                 tracing::debug!(
@@ -679,7 +659,7 @@ async fn control_v3(
             }
             Ok(msg.ack())
         }
-        v3::ControlMessage::Unsubscribe(msg) => {
+        v3::Control::Unsubscribe(msg) => {
             for topic in msg.iter() {
                 tracing::debug!(
                     "MQTT client {} unsubscribes from '{}'",
@@ -689,12 +669,20 @@ async fn control_v3(
             }
             Ok(msg.ack())
         }
-        v3::ControlMessage::Closed(msg) => {
+        v3::Control::WrBackpressure(msg) => {
+            tracing::debug!(
+                "MQTT client {} WrBackpressure received: {}",
+                session.client_id,
+                msg.enabled()
+            );
+            Ok(msg.ack())
+        }
+        v3::Control::Closed(msg) => {
             tracing::debug!("MQTT client {} closed connection", session.client_id);
             session.sink().force_close();
             Ok(msg.ack())
         }
-        v3::ControlMessage::Error(msg) => {
+        v3::Control::Error(msg) => {
             tracing::warn!(
                 "MQTT client {} Error received: {}",
                 session.client_id,
@@ -702,7 +690,7 @@ async fn control_v3(
             );
             Ok(msg.ack())
         }
-        v3::ControlMessage::ProtocolError(ref msg) => {
+        v3::Control::ProtocolError(ref msg) => {
             tracing::warn!(
                 "MQTT client {}: ProtocolError received: {} => disconnect it",
                 session.client_id,
@@ -710,7 +698,7 @@ async fn control_v3(
             );
             Ok(control.disconnect())
         }
-        v3::ControlMessage::PeerGone(msg) => {
+        v3::Control::PeerGone(msg) => {
             tracing::debug!(
                 "MQTT client {}: PeerGone => close connection",
                 session.client_id
@@ -765,8 +753,8 @@ async fn publish_v5(
 
 async fn control_v5(
     session: v5::Session<MqttSessionState>,
-    control: v5::ControlMessage<MqttPluginError>,
-) -> Result<v5::ControlResult, MqttPluginError> {
+    control: v5::Control<MqttPluginError>,
+) -> Result<v5::ControlAck, MqttPluginError> {
     tracing::trace!(
         "MQTT client {} sent control: {:?}",
         session.client_id,
@@ -775,7 +763,7 @@ async fn control_v5(
 
     use v5::codec::{Disconnect, DisconnectReasonCode};
     match control {
-        v5::ControlMessage::Auth(_) => {
+        v5::Control::Auth(_) => {
             tracing::debug!(
                 "MQTT client {} wants to authenticate... not yet supported!",
                 session.client_id
@@ -784,13 +772,13 @@ async fn control_v5(
                 DisconnectReasonCode::ImplementationSpecificError,
             )))
         }
-        v5::ControlMessage::Ping(msg) => Ok(msg.ack()),
-        v5::ControlMessage::Disconnect(msg) => {
+        v5::Control::Ping(msg) => Ok(msg.ack()),
+        v5::Control::Disconnect(msg) => {
             tracing::debug!("MQTT client {} disconnected", session.client_id);
             session.sink().close();
             Ok(msg.ack())
         }
-        v5::ControlMessage::Subscribe(mut msg) => {
+        v5::Control::Subscribe(mut msg) => {
             for mut s in msg.iter_mut() {
                 let topic = s.topic().as_str();
                 tracing::debug!(
@@ -808,7 +796,7 @@ async fn control_v5(
             }
             Ok(msg.ack())
         }
-        v5::ControlMessage::Unsubscribe(msg) => {
+        v5::Control::Unsubscribe(msg) => {
             for topic in msg.iter() {
                 tracing::debug!(
                     "MQTT client {} unsubscribes from '{}'",
@@ -818,12 +806,20 @@ async fn control_v5(
             }
             Ok(msg.ack())
         }
-        v5::ControlMessage::Closed(msg) => {
+        v5::Control::WrBackpressure(msg) => {
+            tracing::debug!(
+                "MQTT client {} WrBackpressure received: {}",
+                session.client_id,
+                msg.enabled()
+            );
+            Ok(msg.ack())
+        }
+        v5::Control::Closed(msg) => {
             tracing::debug!("MQTT client {} closed connection", session.client_id);
             session.sink().close();
             Ok(msg.ack())
         }
-        v5::ControlMessage::Error(msg) => {
+        v5::Control::Error(msg) => {
             tracing::warn!(
                 "MQTT client {} Error received: {}",
                 session.client_id,
@@ -831,7 +827,7 @@ async fn control_v5(
             );
             Ok(msg.ack(DisconnectReasonCode::UnspecifiedError))
         }
-        v5::ControlMessage::ProtocolError(msg) => {
+        v5::Control::ProtocolError(msg) => {
             tracing::warn!(
                 "MQTT client {}: ProtocolError received: {}",
                 session.client_id,
@@ -840,7 +836,7 @@ async fn control_v5(
             session.sink().close();
             Ok(msg.reason_code(DisconnectReasonCode::ProtocolError).ack())
         }
-        v5::ControlMessage::PeerGone(msg) => {
+        v5::Control::PeerGone(msg) => {
             tracing::debug!(
                 "MQTT client {}: PeerGone => close connection",
                 session.client_id


### PR DESCRIPTION
As mentioned in https://github.com/eclipse-zenoh/zenoh-plugin-mqtt/issues/223, now we moved from `aws-lc` to `ring`.