### PR TITLE
removed guess encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,12 +1379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,12 +1637,6 @@ checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
 ]
-
-[[package]]
-name = "iter-read"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
 
 [[package]]
 name = "itertools"
@@ -2025,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-io"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8e90ceb0a9a1bcb57459b8e14c6257519afc8dc3460d68b507fb12e909d02c"
+checksum = "01143e9d77076569b5566092804bc712cf14754583c3828ff56e32a60c8072bf"
 dependencies = [
  "bitflags 2.6.0",
  "log",
@@ -3220,29 +3208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-pickle"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762ad136a26407c6a80825813600ceeab5e613660d93d79a41f0ec877171e71"
-dependencies = [
- "byteorder",
- "iter-read",
- "num-bigint",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
 ]
 
 [[package]]
@@ -4563,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4581,10 +4546,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc_version 0.4.1",
  "serde",
- "serde-pickle",
- "serde_cbor",
  "serde_json",
- "serde_yaml",
  "socket2 0.5.7",
  "tokio",
  "tokio-util",
@@ -4629,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "zenoh-collections",
 ]
@@ -4637,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "tracing",
  "uhlc",
@@ -4648,12 +4610,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "json5",
  "num_cpus",
@@ -4674,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -4685,7 +4647,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "aes 0.8.4",
  "hmac 0.12.1",
@@ -4698,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "hashbrown 0.14.5",
  "keyed-set",
@@ -4712,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4729,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "flume",
@@ -4752,7 +4714,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4777,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4794,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4821,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4840,7 +4802,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "nix",
@@ -4858,7 +4820,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4878,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4919,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4944,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "git-version",
  "libloading",
@@ -4960,7 +4922,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4974,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "anyhow",
 ]
@@ -4982,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4995,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -5008,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "futures",
  "tokio",
@@ -5021,7 +4983,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -5054,7 +5016,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#850171f48be8f1d999fb621ded24dd1f26db7241"
 dependencies = [
  "async-trait",
  "const_format",

--- a/zenoh-plugin-mqtt/src/mqtt_helpers.rs
+++ b/zenoh-plugin-mqtt/src/mqtt_helpers.rs
@@ -17,7 +17,6 @@ use std::convert::TryInto;
 use ntex::util::{ByteString, Bytes};
 use ntex_mqtt::{error::SendPacketError, v3, v5};
 use zenoh::{
-    bytes::Encoding,
     internal::bail,
     key_expr::{KeyExpr, OwnedKeyExpr},
     Result as ZResult,
@@ -101,22 +100,6 @@ pub(crate) fn is_allowed(mqtt_topic: &str, config: &Config) -> bool {
         (None, Some(deny)) => !deny.is_match(mqtt_topic),
         (Some(allow), Some(deny)) => allow.is_match(mqtt_topic) && !deny.is_match(mqtt_topic),
         (None, None) => true,
-    }
-}
-
-pub(crate) fn guess_encoding(payload: &[u8]) -> Encoding {
-    if serde_json::from_slice::<serde_json::Value>(payload).is_ok() {
-        Encoding::APPLICATION_JSON
-    } else if let Ok(s) = std::str::from_utf8(payload) {
-        if s.parse::<i64>().is_ok() {
-            Encoding::ZENOH_INT64
-        } else if s.parse::<f64>().is_ok() {
-            Encoding::ZENOH_FLOAT64
-        } else {
-            Encoding::TEXT_PLAIN
-        }
-    } else {
-        Encoding::default()
     }
 }
 

--- a/zenoh-plugin-mqtt/src/mqtt_session_state.rs
+++ b/zenoh-plugin-mqtt/src/mqtt_session_state.rs
@@ -121,18 +121,15 @@ impl MqttSessionState {
         } else {
             topic.try_into()?
         };
-        let encoding = guess_encoding(payload.deref());
         // TODO: check allow/deny
         tracing::trace!(
-            "MQTT client {}: route from MQTT '{}' to Zenoh '{}' (encoding={})",
+            "MQTT client {}: route from MQTT '{}' to Zenoh '{}'",
             self.client_id,
             topic,
             ke,
-            encoding
         );
         self.zsession
             .put(ke, payload.deref())
-            .encoding(encoding)
             .allowed_destination(destination)
             .await
     }


### PR DESCRIPTION
The `guess_encoding` function sets zenoh packet encoding accordingly to data in received packet. This function is problematic for these reasons:
- it slows down packet processing: each packet is analysed: first parsed as Json, then as unf8 string, etc
- it prone to false positive results: arbitrary data packet may by coincidence become valid Json (just empty `{}` string), valid utf8 string (this is very high probable, etc)
- it incorrectly assigns types `zenoh/int64`, `zenoh/float64` matching them to string representations of the numbers. This is not what these encoding types were made for (now these encodings are removed, but anyway this was a misuse)

So it seems to be safe to just remove this controversial functionality