### PR TITLE
Fix clippy warning in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Code format check
         run: cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
       - name: Clippy
-        run: cargo clippy --all --examples -- -D warnings
+        run: cargo clippy --all-targets --examples -- -D warnings
 
       - name: Build zenoh-plugin-mqtt
         run: cargo build -p zenoh-plugin-mqtt --verbose --all-targets
@@ -59,8 +59,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DavidAnson/markdownlint-cli2-action@v18
         with:
-          config: '.markdownlint.yaml'
-          globs: '**/README.md'
+          config: ".markdownlint.yaml"
+          globs: "**/README.md"
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/zenoh-plugin-mqtt/tests/test.rs
+++ b/zenoh-plugin-mqtt/tests/test.rs
@@ -83,7 +83,7 @@ async fn create_mqtt_subscriber(tx: Sender<String>) {
                     publish.packet().topic,
                     publish.packet().payload
                 );
-                let payload = std::str::from_utf8(&publish.packet().payload.to_vec())
+                let payload = std::str::from_utf8(&publish.packet().payload)
                     .unwrap()
                     .to_owned();
                 tx.send(payload).unwrap();


### PR DESCRIPTION
Fix a clippy warning revealed  by https://github.com/eclipse-zenoh/ci/actions/runs/12763990976/job/35575260925#step:9:787 
And update the CI workflow to use the same clippy flags (`--all-targets` instead of deprecated `--all`).