### PR TITLE
Bump Zenoh and adapt id config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -4783,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "zenoh-collections",
 ]
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "tracing",
  "uhlc",
@@ -4802,7 +4802,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "ahash",
 ]
@@ -4810,7 +4810,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "aes 0.8.4",
  "hmac 0.12.1",
@@ -4858,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "getrandom 0.2.15",
  "hashbrown 0.14.5",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
  "flume",
@@ -4915,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4942,7 +4942,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4959,7 +4959,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4988,13 +4988,15 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
+ "libc",
  "socket2 0.5.7",
  "tokio",
  "tokio-util",
  "tracing",
+ "windows-sys 0.59.0",
  "zenoh-buffers",
  "zenoh-core",
  "zenoh-link-commons",
@@ -5007,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -5025,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5045,7 +5047,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5086,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "anyhow",
  "async-std",
@@ -5111,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "git-version",
  "libloading",
@@ -5127,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -5141,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "anyhow",
 ]
@@ -5149,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "lazy_static",
  "ron",
@@ -5163,7 +5165,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "arc-swap",
  "event-listener 5.3.1",
@@ -5177,7 +5179,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "futures",
  "tokio",
@@ -5190,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -5223,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e8663bdd8ceb84973ebc5276bc73750d9f648a52"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#f9166ccaa7633b77560474a93892ed2710dc7f28"
 dependencies = [
  "async-trait",
  "const_format",

--- a/zenoh-bridge-mqtt/src/main.rs
+++ b/zenoh-bridge-mqtt/src/main.rs
@@ -145,7 +145,9 @@ r#"--root-ca-certificate=[FILE]   'Path to the certificate of the certificate au
     // NOTE: only if args.occurrences_of()>0 to avoid overriding config with the default arg value
     if args.occurrences_of("id") > 0 {
         config
-            .set_id(ZenohId::from_str(args.value_of("id").unwrap()).unwrap())
+            .set_id(Some(
+                ZenohId::from_str(args.value_of("id").unwrap()).unwrap(),
+            ))
             .unwrap();
     }
     if args.occurrences_of("mode") > 0 {


### PR DESCRIPTION
https://github.com/eclipse-zenoh/zenoh/pull/1978 introduced a change to the Zenoh id config, which is now an Option.
This PR bumps Zenoh and adapt to the new id type.