### PR TITLE
ci: fix bump pattern for daily release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,12 @@ jobs:
       live-run: ${{ inputs.live-run || false }}
       version: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
-      bump-deps-version: ${{ inputs.zenoh-version }}
-      bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '' }}
+      bump-deps-version: |
+        ${{ inputs.version }}
+        ${{ inputs.zenoh-version }}
+      bump-deps-pattern: |
+        ^zenoh-plugin-mqtt$
+        ${{ inputs.zenoh-version && 'zenoh.*' || '' }}
       bump-deps-branch: ${{ inputs.zenoh-version && format('release/{0}', inputs.zenoh-version) || '' }}
     secrets: inherit
 


### PR DESCRIPTION
bump pattern needs to bump the plugin but not the zenoh deps during daily release workflow runs