### PR TITLE
feat: Add MQTT retained messages support via Zenoh storage

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -53,6 +53,13 @@
       // tx_channel_size: 65536,
 
       ////
+      //// retained_enabled: Enable MQTT retained messages support (default: true).
+      ////                   Requires Zenoh storage configured for __retained__/** pattern.
+      ////                   See README for storage configuration examples.
+      ////
+      // retained_enabled: true,
+
+      ////
       //// TLS related configuration (MQTTS active only if this part is defined).
       ////
       // tls: {

--- a/zenoh-plugin-mqtt/src/config.rs
+++ b/zenoh-plugin-mqtt/src/config.rs
@@ -62,9 +62,11 @@ pub struct Config {
     pub work_thread_num: usize,
     #[serde(default = "default_max_block_thread_num")]
     pub max_block_thread_num: usize,
-    __required__: Option<bool>,
     #[serde(default)]
     pub auth: Option<AuthConfig>,
+    #[serde(default = "default_retained_enabled")]
+    pub retained_enabled: bool,
+    __required__: Option<bool>,
     #[serde(default, deserialize_with = "deserialize_path")]
     __path__: Option<Vec<String>>,
 }
@@ -117,6 +119,10 @@ fn default_work_thread_num() -> usize {
 
 fn default_max_block_thread_num() -> usize {
     DEFAULT_MAX_BLOCK_THREAD_NUM
+}
+
+fn default_retained_enabled() -> bool {
+    true
 }
 
 struct OptPathVisitor;


### PR DESCRIPTION
Implements MQTT retained message functionality by leveraging Zenoh's storage layer as a pure protocol adapter. The plugin translates MQTT RETAIN flags into Zenoh PUT/DELETE operations and queries Zenoh storage when clients subscribe to topics.

Key changes:
- Add retained_enabled config option (default: true)
- Store retained messages to Zenoh storage at __retained__/<topic>
- Delete retained messages on empty RETAIN payload (per MQTT spec)
- Query Zenoh storage and send retained messages to new subscribers
- Support wildcards in subscriptions for retained message matching

Storage configuration is left to users via Zenoh's storage_manager plugin, allowing flexibility in choosing memory vs persistent backends.

Addresses eclipse-zenoh/zenoh-plugin-mqtt#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)